### PR TITLE
Ignore JSON files in the deployments directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: '18'
       - name: Install dependencies
-        run: yarn
+        run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ artifacts
 deployments/localhost
 
 # Config files
-config.json
+config.json*
 credentials.json*
 
 # Serverless

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "hardhat compile --force",
+    "build": "yarn clean && hardhat compile --force",
+    "clean": "rimraf .esbuild ./artifacts ./cache ./coverage ./typechain-types",
     "deploy:merkle-funder": "DETERMINISTIC=true hardhat deploy --network $NETWORK",
     "deploy:merkle-funder-depositories": "hardhat run ./scripts/deploy-merkle-funder-depositories.ts --network $NETWORK",
     "deploy:watch": "hardhat deploy --watch --network",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "license": "MIT",
   "scripts": {
-    "build": "hardhat compile",
+    "build": "hardhat compile --force",
     "deploy:merkle-funder": "DETERMINISTIC=true hardhat deploy --network $NETWORK",
     "deploy:merkle-funder-depositories": "hardhat run ./scripts/deploy-merkle-funder-depositories.ts --network $NETWORK",
     "deploy:watch": "hardhat deploy --watch --network",

--- a/src/handler.test.ts
+++ b/src/handler.test.ts
@@ -363,7 +363,7 @@ describe('run', () => {
     ];
     const signerAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
     jest.spyOn(fs, 'existsSync').mockReturnValue(true);
-    jest.spyOn(fs, 'readdirSync').mockReturnValue([{ name: 'localhost' }] as Dirent[]);
+    jest.spyOn(fs, 'readdirSync').mockReturnValue([{ name: 'localhost', isDirectory: () => true }] as Dirent[]);
     jest.spyOn(fs, 'readFileSync').mockImplementation((path: PathOrFileDescriptor) => {
       if (path.toString().endsWith('.chainId')) {
         return '31337';

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,6 +13,7 @@ const getMerkleFunderContract = (funderMnemonic: string, providerUrl: string, ch
   }
   const chainDeployment = fs
     .readdirSync(deploymentsPath, { withFileTypes: true })
+    .filter((item) => item.isDirectory())
     .find((item) => fs.readFileSync(path.join(deploymentsPath, item.name, '.chainId'), 'utf-8') === chainId);
   if (!chainDeployment) {
     throw new Error(`No deployment found for chainId: ${chainId}`);

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -13,7 +13,6 @@ const getMerkleFunderContract = (funderMnemonic: string, providerUrl: string, ch
   }
   const chainDeployment = fs
     .readdirSync(deploymentsPath, { withFileTypes: true })
-    .filter((item) => item.isDirectory())
     .find((item) => fs.readFileSync(path.join(deploymentsPath, item.name, '.chainId'), 'utf-8') === chainId);
   if (!chainDeployment) {
     throw new Error(`No deployment found for chainId: ${chainId}`);
@@ -37,7 +36,7 @@ export const run: ScheduledHandler = async (_event: ScheduledEvent, _context: Co
   const config = loadConfig();
 
   const chainFundingResults = await Promise.allSettled(
-    Object.entries(config).map(([chainId, { providers, funderMnemonic, ...chainConfig }]) =>
+    Object.entries(config).flatMap(([chainId, { providers, funderMnemonic, ...chainConfig }]) =>
       Object.entries(providers).map(async ([providerName, provider]) => {
         console.log(`Funding recipients on chain with ID: ${chainId} using provider: ${providerName}`);
 


### PR DESCRIPTION
The `references.json` and `deployment-block-numbers.json` in `deployments/` caused the app to throw. This whole thing should probably depend on `references.json` instead anyway.