### PR TITLE
Estimates gas limit before sending multicall funding txs and uses ful…

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint
+yarn build && yarn lint

--- a/jest.config.js
+++ b/jest.config.js
@@ -26,9 +26,7 @@ module.exports = {
   coverageDirectory: 'coverage',
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  coveragePathIgnorePatterns: ['/node_modules/', '<rootDir>/src/contracts/', '<rootDir>/test/'],
 
   // Indicates which provider should be used to instrument code for coverage
   coverageProvider: 'v8',

--- a/scripts/fund.ts
+++ b/scripts/fund.ts
@@ -1,8 +1,9 @@
+import { LogLevel, LogOptions, logger } from '@api3/airnode-utilities';
 import { go } from '@api3/promise-utils';
 import * as hre from 'hardhat';
+import { MerkleFunder__factory } from '../src';
 import { loadConfig } from '../src/config';
 import { fundChainRecipients } from '../src/merkle-funder';
-import { LogLevel, LogOptions, logger } from '@api3/airnode-utilities';
 
 async function main() {
   const chainId = await hre.getChainId();
@@ -30,11 +31,7 @@ async function main() {
 
   const deployer = await hre.ethers.getSigner(deployerAddress);
 
-  const merkleFunderContract = new hre.ethers.Contract(
-    merkleFunderDeployment.address,
-    merkleFunderDeployment.abi,
-    deployer
-  );
+  const merkleFunderContract = MerkleFunder__factory.connect(merkleFunderDeployment.address, deployer);
 
   const chainConfig = loadConfigResult.data[parseInt(chainId)];
   if (!chainConfig.merkleFunderDepositories) {

--- a/src/evm.test.ts
+++ b/src/evm.test.ts
@@ -90,18 +90,13 @@ describe('estimateMulticallGasLimit', () => {
     expect(result).toEqual(fallbackGasLimit);
   });
 
-  it('should fallback to a default gas limit if no fallbackGasLimit is provided', async () => {
+  it('should throw an error if estimation fails and no fallbackGasLimit is provided', async () => {
     const calldatas = ['0xabcdef', '0x123456'];
 
-    // Mock the estimateGas.multicall function to simulate failure
     mockContract.estimateGas.multicall.mockRejectedValueOnce(new Error('Estimation failed'));
 
-    const result = await estimateMulticallGasLimit(mockContract, calldatas, undefined);
-
-    // Verify that estimateGas.multicall was called with the correct arguments
-    expect(mockContract.estimateGas.multicall).toHaveBeenCalledWith(calldatas);
-
-    // Verify that the result falls back to the default gas limit (2_000_000)
-    expect(result).toEqual(ethers.BigNumber.from(2_000_000));
+    await expect(estimateMulticallGasLimit(mockContract, calldatas, undefined)).rejects.toThrowError(
+      'Unable to estimate gas limit'
+    );
   });
 });

--- a/src/evm.test.ts
+++ b/src/evm.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import { generateRandomAddress, generateRandomBytes32 } from '../test/test-utils';
 import { MerkleFunderDepository__factory } from './contracts';
-import { computeMerkleFunderDepositoryAddress, decodeRevertString } from './evm';
+import { computeMerkleFunderDepositoryAddress, decodeRevertString, estimateMulticallGasLimit } from './evm';
 
 describe('computeMerkleFunderDepositoryAddress', () => {
   it('should compute the correct MerkleFunderDepository address', async () => {
@@ -46,5 +46,62 @@ describe('decodeRevertString', () => {
 
     const result = decodeRevertString(returndata);
     expect(result).toEqual(expectedRevertString);
+  });
+});
+
+describe('estimateMulticallGasLimit', () => {
+  let mockContract: any;
+
+  beforeEach(() => {
+    mockContract = {
+      estimateGas: {
+        multicall: jest.fn(),
+      },
+    };
+  });
+
+  it('should estimate gas limit successfully', async () => {
+    const calldatas = ['0xabcdef', '0x123456'];
+    const fallbackGasLimit = ethers.BigNumber.from(3_000_000);
+
+    const estimatedGas = ethers.BigNumber.from(2500000);
+    mockContract.estimateGas.multicall.mockResolvedValueOnce(estimatedGas);
+
+    const result = await estimateMulticallGasLimit(mockContract, calldatas, fallbackGasLimit);
+
+    expect(mockContract.estimateGas.multicall).toHaveBeenCalledWith(calldatas);
+
+    const expectedGasLimit = estimatedGas
+      .mul(ethers.BigNumber.from(Math.round(1.1 * 100)))
+      .div(ethers.BigNumber.from(100));
+    expect(result).toEqual(expectedGasLimit);
+  });
+
+  it('should fallback to provided gas limit if estimation fails', async () => {
+    const calldatas = ['0xabcdef', '0x123456'];
+    const fallbackGasLimit = ethers.BigNumber.from(3_000_000);
+
+    mockContract.estimateGas.multicall.mockRejectedValueOnce(new Error('Estimation failed'));
+
+    const result = await estimateMulticallGasLimit(mockContract, calldatas, fallbackGasLimit);
+
+    expect(mockContract.estimateGas.multicall).toHaveBeenCalledWith(calldatas);
+
+    expect(result).toEqual(fallbackGasLimit);
+  });
+
+  it('should fallback to a default gas limit if no fallbackGasLimit is provided', async () => {
+    const calldatas = ['0xabcdef', '0x123456'];
+
+    // Mock the estimateGas.multicall function to simulate failure
+    mockContract.estimateGas.multicall.mockRejectedValueOnce(new Error('Estimation failed'));
+
+    const result = await estimateMulticallGasLimit(mockContract, calldatas, undefined);
+
+    // Verify that estimateGas.multicall was called with the correct arguments
+    expect(mockContract.estimateGas.multicall).toHaveBeenCalledWith(calldatas);
+
+    // Verify that the result falls back to the default gas limit (2_000_000)
+    expect(result).toEqual(ethers.BigNumber.from(2_000_000));
   });
 });

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -53,5 +53,9 @@ export const estimateMulticallGasLimit = async (
     return goEstimateGas.data.mul(ethers.BigNumber.from(Math.round(1.1 * 100))).div(ethers.BigNumber.from(100));
   }
 
-  return fallbackGasLimit ?? ethers.BigNumber.from(2_000_000);
+  if (!fallbackGasLimit) {
+    throw new Error('Unable to estimate gas limit');
+  }
+
+  return fallbackGasLimit;
 };

--- a/src/evm.ts
+++ b/src/evm.ts
@@ -49,7 +49,7 @@ export const estimateMulticallGasLimit = async (
 ) => {
   const goEstimateGas = await go(async () => contract.estimateGas.multicall(calldatas));
   if (goEstimateGas.success) {
-    // Adding a extra 10% because multicall consumes less gas than tryMulticall
+    // Adding an extra 10% because multicall consumes less gas than tryMulticall
     return goEstimateGas.data.mul(ethers.BigNumber.from(Math.round(1.1 * 100))).div(ethers.BigNumber.from(100));
   }
 

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -18,7 +18,7 @@ const getMerkleFunderContract = (funderMnemonic: string, providerUrl: string, ch
   const signer = ethers.Wallet.fromMnemonic(funderMnemonic).connect(provider);
 
   // Return the merkleFunder contract
-  return new ethers.Contract(merkleFunderAddress, MerkleFunder__factory.abi, signer);
+  return MerkleFunder__factory.connect(merkleFunderAddress, signer);
 };
 
 export const run: ScheduledHandler = async (_event: ScheduledEvent, _context: Context): Promise<void> => {

--- a/src/merkle-funder.test.ts
+++ b/src/merkle-funder.test.ts
@@ -1,20 +1,15 @@
+import { ethers } from 'ethers';
+
 const getGasPriceMock = jest.fn().mockResolvedValue([
   [{ message: 'mocked-get-gas-price-message' }],
   {
     type: 0,
-    gasPrice: {
-      type: 'BigNumber',
-      hex: '0x02540be400',
-    },
-    gasLimit: {
-      type: 'BigNumber',
-      hex: '0x030d40',
-    },
+    gasPrice: ethers.BigNumber.from(10_000_000_000),
+    gasLimit: ethers.BigNumber.from(200_000),
   },
 ]);
 
 import { LogOptions, logger } from '@api3/airnode-utilities';
-import { ethers } from 'ethers';
 import * as evmModule from './evm';
 import { fundChainRecipients } from './merkle-funder';
 import buildMerkleTree from './merkle-tree';
@@ -136,25 +131,28 @@ describe('fundChainRecipients', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const loggerErrorSpy = jest.spyOn(logger, 'error');
 
-    await fundChainRecipients(
-      '31337',
-      { options, merkleFunderDepositories },
-      mockContract as unknown as ethers.Contract,
-      logOptions
-    );
+    await fundChainRecipients('31337', { options, merkleFunderDepositories }, mockContract as any, logOptions);
 
     expect(buildMerkleTree).toHaveBeenCalledTimes(1);
     expect(buildMerkleTree).toHaveBeenCalledWith(values);
     expect(loggerInfoSpy).toHaveBeenCalledWith('Processing 1 merkleFunderDepositories...', logOptions);
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber()');
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof1, values[0].recipient, ethers.utils.parseEther('10'), ethers.utils.parseEther('20')]
-    );
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof2, values[1].recipient, ethers.utils.parseEther('5'), ethers.utils.parseEther('15')]
-    );
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber');
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof1,
+      values[0].recipient,
+      ethers.utils.parseEther('10'),
+      ethers.utils.parseEther('20'),
+    ]);
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof2,
+      values[1].recipient,
+      ethers.utils.parseEther('5'),
+      ethers.utils.parseEther('15'),
+    ]);
     const [, ...multicallCalldata] = staticMulticallCalldata;
     expect(mockContractCallStaticTryMulticall).toHaveBeenCalledWith(staticMulticallCalldata);
     expect(loggerErrorSpy).not.toHaveBeenCalledWith(
@@ -283,25 +281,28 @@ describe('fundChainRecipients', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const loggerErrorSpy = jest.spyOn(logger, 'error');
 
-    await fundChainRecipients(
-      '31337',
-      { options, merkleFunderDepositories },
-      mockContract as unknown as ethers.Contract,
-      logOptions
-    );
+    await fundChainRecipients('31337', { options, merkleFunderDepositories }, mockContract as any, logOptions);
 
     expect(buildMerkleTree).toHaveBeenCalledTimes(1);
     expect(buildMerkleTree).toHaveBeenCalledWith(values);
     expect(loggerInfoSpy).toHaveBeenCalledWith('Processing 1 merkleFunderDepositories...', logOptions);
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber()');
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof1, values[0].recipient, ethers.utils.parseEther('10'), ethers.utils.parseEther('20')]
-    );
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof2, values[1].recipient, ethers.utils.parseEther('5'), ethers.utils.parseEther('15')]
-    );
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber');
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof1,
+      values[0].recipient,
+      ethers.utils.parseEther('10'),
+      ethers.utils.parseEther('20'),
+    ]);
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof2,
+      values[1].recipient,
+      ethers.utils.parseEther('5'),
+      ethers.utils.parseEther('15'),
+    ]);
     expect(mockContractCallStaticTryMulticall).toHaveBeenCalledWith(staticMulticallCalldata);
     expect(loggerInfoSpy).toHaveBeenCalledWith(
       'Block number fetched while testing funding of recipients: 10',
@@ -420,25 +421,28 @@ describe('fundChainRecipients', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const loggerErrorSpy = jest.spyOn(logger, 'error');
 
-    await fundChainRecipients(
-      '31337',
-      { options, merkleFunderDepositories },
-      mockContract as unknown as ethers.Contract,
-      logOptions
-    );
+    await fundChainRecipients('31337', { options, merkleFunderDepositories }, mockContract as any, logOptions);
 
     expect(buildMerkleTree).toHaveBeenCalledTimes(1);
     expect(buildMerkleTree).toHaveBeenCalledWith(values);
     expect(loggerInfoSpy).toHaveBeenCalledWith('Processing 1 merkleFunderDepositories...', logOptions);
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber()');
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof1, values[0].recipient, ethers.utils.parseEther('10'), ethers.utils.parseEther('20')]
-    );
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof2, values[1].recipient, ethers.utils.parseEther('5'), ethers.utils.parseEther('15')]
-    );
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('getBlockNumber');
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof1,
+      values[0].recipient,
+      ethers.utils.parseEther('10'),
+      ethers.utils.parseEther('20'),
+    ]);
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof2,
+      values[1].recipient,
+      ethers.utils.parseEther('5'),
+      ethers.utils.parseEther('15'),
+    ]);
     expect(mockContractCallStaticTryMulticall).toHaveBeenCalledWith(staticMulticallCalldata);
     expect(loggerInfoSpy).toHaveBeenCalledWith(
       'Block number fetched while testing funding of recipients: 10',
@@ -542,20 +546,19 @@ describe('fundChainRecipients', () => {
     const loggerInfoSpy = jest.spyOn(logger, 'info');
     const loggerErrorSpy = jest.spyOn(logger, 'error');
 
-    await fundChainRecipients(
-      '31337',
-      { options, merkleFunderDepositories },
-      mockContract as unknown as ethers.Contract,
-      logOptions
-    );
+    await fundChainRecipients('31337', { options, merkleFunderDepositories }, mockContract as any, logOptions);
 
     expect(buildMerkleTree).toHaveBeenCalledTimes(1);
     expect(buildMerkleTree).toHaveBeenCalledWith(values);
     expect(loggerInfoSpy).toHaveBeenCalledWith('Processing 1 merkleFunderDepositories...', logOptions);
-    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith(
-      'fund(address,bytes32,bytes32[],address,uint256,uint256)',
-      [owner, treeRoot, proof1, values[0].recipient, ethers.utils.parseEther('10'), ethers.utils.parseEther('20')]
-    );
+    expect(mockContract.interface.encodeFunctionData).toHaveBeenCalledWith('fund', [
+      owner,
+      treeRoot,
+      proof1,
+      values[0].recipient,
+      ethers.utils.parseEther('10'),
+      ethers.utils.parseEther('20'),
+    ]);
     const [, ...multicallCalldata] = staticMulticallCalldata;
     expect(loggerInfoSpy).toHaveBeenCalledWith('Funding test of 0xrecipient1 succeeded', logOptions);
     expect(mockContractCallStaticTryMulticall).toHaveBeenCalledWith(staticMulticallCalldata);


### PR DESCRIPTION
…fillmentGasLimit from config as fallback

### What this PR changes

Previous to this PR `fulfillmentGasLimit` from config.json was being used to override the `gasLimit` on the `tryMulticall` tx to fund recipients. Now similarly to airseeker and airseeker-v2, merkle-funder will estimate the the `gasLimit` for the `multicall` tx and add an extra 10% to account for `tryMulticall` consuming a bit more gas.

`fulfillmentGasLimit` can still be set on the config but it will only be used as fallback for when the worker fails to get an estimate from the provider. If no `fulfillmentGasLimit` is set on the config and the worker is not able to get an estimate then a default of `2_000_000` will be used as last resort.